### PR TITLE
Optimistic variant of MWU, and a variant of the Extragradient Method

### DIFF
--- a/ordinal_potential_games/FLBR_MWU.py
+++ b/ordinal_potential_games/FLBR_MWU.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def FLBR_multiplicative_weights_update(meta_games, num_iterations, step_size, alternate=False):
+def FLBR_multiplicative_weights_update(meta_games, num_iterations, step_size=None, alternate=False):
     num_players = len(meta_games)
     n, m = np.shape(meta_games[0])
 
@@ -9,7 +9,7 @@ def FLBR_multiplicative_weights_update(meta_games, num_iterations, step_size, al
 
     last_weights = [np.ones(n)/n, np.ones(m)/m]
     weights = [np.ones(n) / n, np.ones(m) / m]
-    print(step_size)
+
     for i in range(num_iterations):
         if alternate:
             used_weights = weights

--- a/ordinal_potential_games/FLBR_MWU.py
+++ b/ordinal_potential_games/FLBR_MWU.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+def FLBR_multiplicative_weights_update(meta_games, num_iterations, step_size, alternate=False):
+    num_players = len(meta_games)
+    n, m = np.shape(meta_games[0])
+
+    if step_size is None:
+        step_size = min(np.sqrt(8 * np.log(n)/num_iterations), np.sqrt(8 * np.log(m)/num_iterations))
+
+    last_weights = [np.ones(n)/n, np.ones(m)/m]
+    weights = [np.ones(n) / n, np.ones(m) / m]
+    print(step_size)
+    for i in range(num_iterations):
+        if alternate:
+            used_weights = weights
+        else:
+            weights = last_weights
+        
+        int_weights = intermediate_step(meta_games, weights, step_size)
+        
+        new_weights = weights[0] * np.exp(step_size * np.squeeze(np.dot(meta_games[0], int_weights[1])))
+        weights[0] = new_weights / np.sum(new_weights)
+
+        new_weights = weights[1] * np.exp(step_size * np.squeeze(np.dot(np.reshape(int_weights[0], (1,-1)), meta_games[1])))
+        weights[1] = new_weights / np.sum(new_weights)
+
+        if not alternate:
+            last_weights[0] = np.copy(weights[0])
+            last_weights[1] = np.copy(weights[1])
+
+    for player in range(num_players):
+        weights[player] /= np.sum(weights[player])
+    
+    return weights
+    
+def intermediate_step(meta_games, weights, eta):
+    tmp1 = np.multiply(weights[0], np.exp(eta*np.dot(meta_games[0], weights[1])))
+    s_tmp1 = np.inner(weights[0], np.exp(eta*np.dot(meta_games[0], weights[1])))
+
+    tmp2 = np.multiply(weights[1], np.exp(eta*np.dot(np.transpose(meta_games[1]), weights[0])))
+    s_tmp2 = np.inner(weights[1], np.exp(eta*np.dot(np.transpose(meta_games[1]), weights[0])))
+    
+    return [tmp1/s_tmp1, tmp2/s_tmp2]

--- a/ordinal_potential_games/Optimistic_MWU.py
+++ b/ordinal_potential_games/Optimistic_MWU.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+def optimistic_multiplicative_weights_update(meta_games, num_iterations, step_size, alternate=False):
+    """
+    Implement the optimistic multiplicative weights update for two-player games only.
+    :param meta_games: two lists of payoffs, one for each player.
+    :param num_iterations: Number of iterations for MWU.
+    :param step_size: The value of step size for MWU.
+    :param alternate: Make the updates alternate between players.
+    :return: A mixed strategy profile in a list.
+    """
+    num_players = len(meta_games)
+    n, m = np.shape(meta_games[0])
+
+    if step_size is None:
+        step_size = min(np.sqrt(8 * np.log(n)/num_iterations), np.sqrt(8 * np.log(m)/num_iterations))
+
+    last_weights = [np.ones(n) / n, np.ones(m) / m]
+    sec_last_weights = last_weights
+    weights = [np.ones(n) / n, np.ones(m) / m]
+    for i in range(num_iterations):
+        if alternate:
+            last_weights = used_weights
+            used_weights = weights
+        else:
+            used_weights = weights
+
+        new_weights = weights[0] * \
+            np.exp(step_size * ( np.squeeze(2*np.dot(meta_games[0], used_weights[1]) - \
+                                            np.dot(meta_games[0], last_weights[1]))))
+        weights[0] = new_weights / np.sum(new_weights)
+
+        new_weights = weights[1] * \
+            np.exp(step_size * np.squeeze(2*np.dot(np.reshape(used_weights[0], (1,-1)), meta_games[1]) -\
+                                          np.dot(np.reshape(last_weights[0], (1,-1)), meta_games[1])))
+        weights[1] = new_weights / np.sum(new_weights)
+
+        if not alternate:
+            sec_last_weights[0] = last_weights[0]
+            sec_last_weights[1] = last_weights[1]
+            last_weights[0] = np.copy(used_weights[0])
+            last_weights[1] = np.copy(used_weights[1])
+
+    for player in range(num_players):
+        weights[player] /= np.sum(weights[player])
+
+    return weights

--- a/ordinal_potential_games/Optimistic_MWU.py
+++ b/ordinal_potential_games/Optimistic_MWU.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-def optimistic_multiplicative_weights_update(meta_games, num_iterations, step_size, alternate=False):
+def optimistic_multiplicative_weights_update(meta_games, num_iterations, step_size=None, alternate=False):
     """
     Implement the optimistic multiplicative weights update for two-player games only.
     :param meta_games: two lists of payoffs, one for each player.
-    :param num_iterations: Number of iterations for MWU.
-    :param step_size: The value of step size for MWU.
+    :param num_iterations: Number of iterations for OMWU.
+    :param step_size: The value of step size for OMWU.
     :param alternate: Make the updates alternate between players.
     :return: A mixed strategy profile in a list.
     """

--- a/ordinal_potential_games/main_MWU.py
+++ b/ordinal_potential_games/main_MWU.py
@@ -9,7 +9,6 @@ def main():
     dim = 2
     num_iterations = 50
     potential, games = runner(dim)
-    games.append([np.array([[2, -1], [-1, 4]]), np.array([[-2, 1], [1, -4]])])
     print("The potential is \n", potential)
     for i, game in enumerate(games):
         print("###### Running the game {} ######".format(i))

--- a/ordinal_potential_games/main_MWU.py
+++ b/ordinal_potential_games/main_MWU.py
@@ -1,21 +1,35 @@
+import numpy as np
 from ordinal_game_generator import runner
 from MWU import multiplicative_weights_update
+from Optimistic_MWU import optimistic_multiplicative_weights_update
+from FLBR_MWU import FLBR_multiplicative_weights_update
 from solution_solvers.nash_solver.pygambit_solver import pygbt_solve_matrix_games
 
 def main():
     dim = 2
-    num_iterations = 10
+    num_iterations = 50
     potential, games = runner(dim)
+    games.append([np.array([[2, -1], [-1, 4]]), np.array([[-2, 1], [1, -4]])])
     print("The potential is \n", potential)
     for i, game in enumerate(games):
         print("###### Running the game {} ######".format(i))
         weights = multiplicative_weights_update(game,
                                                 num_iterations=num_iterations,
                                                 alternate=False)
+                                                
+        weights1 = optimistic_multiplicative_weights_update(game,
+                                                num_iterations=num_iterations,
+                                                alternate=False)                                                       
 
+        weights2 = FLBR_multiplicative_weights_update(game,
+                                                num_iterations=num_iterations,
+                                                alternate=False)
+                                                
         ne = pygbt_solve_matrix_games(game, mode="all")
         print("Game:", game)
         print("MWU weights:", weights)
+        print("OMWU weights:", weights1)
+        print("FLBR weights:", weights2)
         print("NE:", ne)
 
 main()


### PR DESCRIPTION
There are two methods. The first one is the Optimistic Multiplicative Weights Update method, and the second one is the Forward Looking Best-Response Multiplicative Weights Update method. Both attain point-wise convergence in the case of 2-player zero-sum games.